### PR TITLE
Add automatic opening of embedded player

### DIFF
--- a/background.js
+++ b/background.js
@@ -17,15 +17,16 @@ chrome.extension.onMessage.addListener(
         return true;
     } else if (request.name == "getOptions") {
         var defaults = {
-            "textlinks":        1,
-            "imglinks":         0,
-            "embed":            1,
-            "embedleft":        0,
-            "replacename":      1,
-            "tooltip":          1,
-            "timestamp":        0,
-            "timestamptooltip": 1,
-            "restrictedicon":   1,
+            "textlinks":            1,
+            "imglinks":             0,
+            "embed":                1,
+            "embedleft":            0,
+            "showEmbeddedPlayer":   0,
+            "replacename":          1,
+            "tooltip":              1,
+            "timestamp":            0,
+            "timestamptooltip":     1,
+            "restrictedicon":       1,
         };
 
         var resp = {};

--- a/options.html
+++ b/options.html
@@ -96,6 +96,19 @@
         <li>
           <div>
             <div class="label">
+              <span>Show inline embedded player automatically</span>
+            </div>
+            
+            <div class="slideThree">  
+              <input type="checkbox" id="showEmbeddedPlayer" name="showEmbeddedPlayer" />
+              <label for="showEmbeddedPlayer"></label>
+            </div>
+          </div>
+        </li>
+
+        <li>
+          <div>
+            <div class="label">
               <span>Show tooltip with information when hovering over YouTube links:</span>
             </div>
             

--- a/script.js
+++ b/script.js
@@ -31,6 +31,7 @@ $(document).ready(function () {
         YTTA.timestamptooltip = resp["timestamptooltip"]*1;
         YTTA.restrictedicon = resp["restrictedicon"]*1;
         YTTA.embedleft = resp["embedleft"]*1;
+        YTTA.showEmbeddedPlayer = resp["showEmbeddedPlayer"]*1;
 
         var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
         var observer = new MutationObserver( function (mutations) {
@@ -112,7 +113,7 @@ function addTitle(resp) {
             var embedhtml = '<img src="' + YTTA.EMBED_IMG + '" ' +
                             'class="' + YTTA.CLASS_EMBED_ICON + '" ' +
                             'title="Click to play video inline." />' +
-                            '<div class="' + YTTA.CLASS_EMBED_DISABLED + '">' +
+                            '<div class="' + (YTTA.showEmbeddedPlayer ? YTTA.CLASS_EMBED_ENABLED : YTTA.CLASS_EMBED_DISABLED) + '">' +
                             embed +
                             '</div>';
             var embedimg;


### PR DESCRIPTION
## Proposed Changes

1. Add a new option to enable/disable the automatic opening of the embedded player
2. Adjust the CSS class that is added when the embedded player is created

### Expected Behaviour
The embedded player appears opened always.

![auto-expanding-player](https://user-images.githubusercontent.com/18509578/66901163-e7939b00-f049-11e9-9b9b-47d977304d42.gif)


### Previous Behaviour
The player would start hidden and the user would need to click on a button to show it.
