### PR TITLE
Fix default link from opening on click

### DIFF
--- a/script.js
+++ b/script.js
@@ -126,6 +126,8 @@ function addTitle(resp) {
             }
 
             embedimg.on('click', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
                 var embeddiv = $(e.target).next();
                 if (embeddiv.hasClass(YTTA.CLASS_EMBED_DISABLED)) {
                     embeddiv.removeClass(YTTA.CLASS_EMBED_DISABLED);


### PR DESCRIPTION
## Proposed Changes

- Add `preventDefault` + `stopPropagation` to the embedded players click event

This will prevent the underlying link from opening when the user actually wants to show or hide the embedded player.

### Expected Behaviour
![prevent-default](https://user-images.githubusercontent.com/18509578/66901867-41e12b80-f04b-11e9-9dde-2d72f2d92480.gif)

### Previous Behaviour
![opens-link](https://user-images.githubusercontent.com/18509578/66901894-5291a180-f04b-11e9-8967-926aa000f173.gif)
